### PR TITLE
Sam customer order

### DIFF
--- a/bangazon_website/bang_app/models/__init__.py
+++ b/bangazon_website/bang_app/models/__init__.py
@@ -2,3 +2,4 @@ from .customer import Customer
 from .product import Product
 from .product_type import ProductType
 from .payment_type import PaymentType
+from .customer_order import CustomerOrder

--- a/bangazon_website/bang_app/models/customer_order.py
+++ b/bangazon_website/bang_app/models/customer_order.py
@@ -1,6 +1,7 @@
 from django.db import models
 from .customer import Customer
 from .payment_type import PaymentType
+from .product import Product
 
 class CustomerOrder(models.Model):
     """
@@ -12,6 +13,7 @@ class CustomerOrder(models.Model):
     active_order = models.IntegerField()
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
     payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE)
+    line_items = models.ManyToManyField(Product, db_table="LineItem", related_name='customer_orders')
 
     def __str__(self):
-        return "Order for customer {}".format(Customer.objects.get(pk=self.Customer))
+        return "Order for customer {}".format(self.customer)

--- a/bangazon_website/bang_app/models/customer_order.py
+++ b/bangazon_website/bang_app/models/customer_order.py
@@ -1,0 +1,17 @@
+from django.db import models
+from .customer import Customer
+from .payment_type import PaymentType
+
+class CustomerOrder(models.Model):
+    """
+    Purpose: Maintain information relevant to a Customer's order
+
+    Author: Sam Phillips
+    """
+
+    active_order = models.IntegerField()
+    customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+    payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return "Order for customer {}".format(Customer.objects.get(pk=self.Customer))

--- a/bangazon_website/bang_app/models/customer_order.py
+++ b/bangazon_website/bang_app/models/customer_order.py
@@ -9,12 +9,11 @@ class CustomerOrder(models.Model):
 
     Author: Sam Phillips
     """
-
+    
     active_order = models.IntegerField()
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
     payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE)
-    line_items = models.ManyToManyField(Product)
-    # line_items = models.ManyToManyField(Product, db_table="LineItem", related_name='customer_orders')
+    line_items = models.ManyToManyField(Product, db_table="LineItem")
 
     def __str__(self):
         return "Order for customer {}".format(self.customer)

--- a/bangazon_website/bang_app/models/customer_order.py
+++ b/bangazon_website/bang_app/models/customer_order.py
@@ -13,7 +13,8 @@ class CustomerOrder(models.Model):
     active_order = models.IntegerField()
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
     payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE)
-    line_items = models.ManyToManyField(Product, db_table="LineItem", related_name='customer_orders')
+    line_items = models.ManyToManyField(Product)
+    # line_items = models.ManyToManyField(Product, db_table="LineItem", related_name='customer_orders')
 
     def __str__(self):
         return "Order for customer {}".format(self.customer)

--- a/bangazon_website/bang_app/tests/test_customer_order_model.py
+++ b/bangazon_website/bang_app/tests/test_customer_order_model.py
@@ -1,0 +1,56 @@
+from django.test import TestCase 
+from bang_app.models import CustomerOrder, Customer, PaymentType
+from django.contrib.auth.models import User
+
+class TestCustomerOrderCreation(TestCase):
+    """
+    Purpost: Tests the instantiation of a CustomerOrder instance to ensure
+    all values are correctly assigned
+    """
+
+    @classmethod
+    def setUpTestData(self):
+        self.user = User(
+            first_name = "Suzy",
+            last_name = "Bishop",
+            email = "s@s.com",
+            username = "suzybishop",
+            password="password1234"
+            )
+
+        self.suzy = Customer(
+            user = self.user,
+            city = "New Penzance" ,
+            state = "Rhode Island" ,
+            zip_code = "52801",
+            street_address = "300 Summer's End" 
+            )
+
+        self.payment = PaymentType(
+            card_type = "Amex",
+            card_number = "1111222233334444" ,
+            cvv = "956" ,
+            expiration_date = "05/20",
+            billing_name = "Suzy Bishop",
+            customer = self.suzy
+            )
+
+        self.new_customer_order = CustomerOrder(
+            active_order=1, 
+            customer=self.suzy, 
+            payment_type=self.payment
+        )
+        # self.new_customer_order = CustomerOrder(1, 1, 1)
+
+
+    def test_new_order_is_of_class_CustomerOrder(self):
+        self.assertIsInstance(self.new_customer_order, CustomerOrder)
+
+    def test_new_order_values_are_assigned_correctly(self):
+        self.assertEqual(self.new_customer_order.active_order, 1)
+        self.assertEqual(self.new_customer_order.customer, self.suzy)
+        self.assertEqual(self.new_customer_order.payment_type, self.payment)
+
+
+
+

--- a/bangazon_website/bang_app/tests/test_customer_order_model.py
+++ b/bangazon_website/bang_app/tests/test_customer_order_model.py
@@ -16,7 +16,7 @@ class TestCustomerOrderCreation(TestCase):
             email = "s@s.com",
             username = "suzybishop",
             password="password1234"
-            )
+        )
 
         self.suzy = Customer(
             user = self.user,
@@ -24,7 +24,7 @@ class TestCustomerOrderCreation(TestCase):
             state = "Rhode Island" ,
             zip_code = "52801",
             street_address = "300 Summer's End" 
-            )
+        )
 
         self.payment = PaymentType(
             card_type = "Amex",
@@ -33,14 +33,13 @@ class TestCustomerOrderCreation(TestCase):
             expiration_date = "05/20",
             billing_name = "Suzy Bishop",
             customer = self.suzy
-            )
+        )
 
         self.new_customer_order = CustomerOrder(
             active_order=1, 
             customer=self.suzy, 
             payment_type=self.payment
         )
-        # self.new_customer_order = CustomerOrder(1, 1, 1)
 
 
     def test_new_order_is_of_class_CustomerOrder(self):
@@ -50,7 +49,3 @@ class TestCustomerOrderCreation(TestCase):
         self.assertEqual(self.new_customer_order.active_order, 1)
         self.assertEqual(self.new_customer_order.customer, self.suzy)
         self.assertEqual(self.new_customer_order.payment_type, self.payment)
-
-
-
-

--- a/bangazon_website/bang_app/tests/test_customer_order_model.py
+++ b/bangazon_website/bang_app/tests/test_customer_order_model.py
@@ -49,3 +49,12 @@ class TestCustomerOrderCreation(TestCase):
         self.assertEqual(self.new_customer_order.active_order, 1)
         self.assertEqual(self.new_customer_order.customer, self.suzy)
         self.assertEqual(self.new_customer_order.payment_type, self.payment)
+        self.assertEqual(self.new_customer_order.line_items, [])
+
+
+
+
+
+
+
+

--- a/bangazon_website/bang_app/tests/test_customer_order_model.py
+++ b/bangazon_website/bang_app/tests/test_customer_order_model.py
@@ -1,5 +1,5 @@
 from django.test import TestCase 
-from bang_app.models import CustomerOrder, Customer, PaymentType
+from bang_app.models import CustomerOrder, Customer, PaymentType, Product
 from django.contrib.auth.models import User
 
 class TestCustomerOrderCreation(TestCase):
@@ -17,6 +17,7 @@ class TestCustomerOrderCreation(TestCase):
             username = "suzybishop",
             password="password1234"
         )
+        self.user.save()
 
         self.suzy = Customer(
             user = self.user,
@@ -25,6 +26,7 @@ class TestCustomerOrderCreation(TestCase):
             zip_code = "52801",
             street_address = "300 Summer's End" 
         )
+        self.suzy.save()
 
         self.payment = PaymentType(
             card_type = "Amex",
@@ -34,12 +36,21 @@ class TestCustomerOrderCreation(TestCase):
             billing_name = "Suzy Bishop",
             customer = self.suzy
         )
+        self.payment.save()
 
         self.new_customer_order = CustomerOrder(
             active_order=1, 
             customer=self.suzy, 
             payment_type=self.payment
         )
+        self.new_customer_order.save()
+
+        ball = Product(None, "ball", 1.99, "It's round", 3, 1, 1)
+        ball.save()
+        
+        self.testing_product = Product.objects.get(pk=1)
+
+        self.new_customer_order.line_items.add(self.testing_product)
 
 
     def test_new_order_is_of_class_CustomerOrder(self):

--- a/bangazon_website/bang_app/tests/test_customer_order_model.py
+++ b/bangazon_website/bang_app/tests/test_customer_order_model.py
@@ -47,7 +47,7 @@ class TestCustomerOrderCreation(TestCase):
 
         ball = Product(None, "ball", 1.99, "It's round", 3, 1, 1)
         ball.save()
-        
+
         self.testing_product = Product.objects.get(pk=1)
 
         self.new_customer_order.line_items.add(self.testing_product)
@@ -60,7 +60,8 @@ class TestCustomerOrderCreation(TestCase):
         self.assertEqual(self.new_customer_order.active_order, 1)
         self.assertEqual(self.new_customer_order.customer, self.suzy)
         self.assertEqual(self.new_customer_order.payment_type, self.payment)
-        self.assertEqual(self.new_customer_order.line_items, [])
+
+        self.assertEqual(self.new_customer_order.line_items.all()[0], Product.objects.get(pk=1))
 
 
 

--- a/bangazon_website/bang_app/tests/test_payment_type.py
+++ b/bangazon_website/bang_app/tests/test_payment_type.py
@@ -1,5 +1,4 @@
 from django.test import TestCase 
-import sys
 from bang_app.models import PaymentType
 
 class TestPaymentTypeCreation(TestCase):


### PR DESCRIPTION
## Description
This creates the CustomerOrder model, which contains the following fields:
1. **active_order** (either a 0 or a 1, 0 means an order is inactive and 1 means the order is active)
1. **customer** (foreign key to a customer)
1. **payment_type** (foreign key to a payment_type)
1. **line_items** (many to many field where instances of products can be added to represent line items on the order)

## Number of Fixes
No fixes, simply creating the CustomerOrder model.


## Related Ticket(s)
#9, #2


## Problem to Solve
Their needs to be a way for customers to order products off the Bangazon website.


## Expected Behavior
All tests relating to CustomerOrder should pass. Nothing tied into any views yet.


## Steps to Test Solution
From the root of the Django project, run the following commands:
```
git fetch --all
git checkout origin/sam-CustomerOrder
rm -rf bang_app/migrations 
python manage.py makemigrations bang_app
python manage.py migrate
python manage.py test bang_app
python manage.py runserver
```

All tests relating to this new module should pass. The server should run without any problem, although this model hasn't been implemented in the application yet.


## Unit Testing
- [X] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [X] I certify that all existing tests pass

## Documentation

- [X] There is new documentation in this pull request that must be reviewed..
- [X] I added documentation for any new classes/methods

## Deploy Notes
IF you didn't run them from the section above, the following commands will need to be run for the system to recognize the changes:
```
rm -rf bang_app/migrations 
python manage.py makemigrations bang_app
python manage.py migrate
```